### PR TITLE
add controllers plugin

### DIFF
--- a/app/routes/auth.js
+++ b/app/routes/auth.js
@@ -2,12 +2,7 @@
 
 exports.register = function(plugin, options, next) {
 
-    let Controllers = {
-        auth: {
-            login: require('../controllers/auth/login'),
-            logout: require('../controllers/auth/logout')
-        }
-    };
+    let Controllers = plugin.controllers();
 
     plugin.route([
 

--- a/app/routes/core.js
+++ b/app/routes/core.js
@@ -2,12 +2,7 @@
 
 exports.register = function(plugin, options, next) {
 
-    var Controllers = {
-        core: {
-            fallback: require('../controllers/core/fallback'),
-            static: require('../controllers/core/static')
-        }
-    };
+    var Controllers = plugin.controllers();
 
     plugin.route([
 

--- a/app/routes/pages.js
+++ b/app/routes/pages.js
@@ -2,11 +2,7 @@
 
 exports.register = function(plugin, options, next) {
 
-    var Controllers = {
-        pages: {
-            home: require('../controllers/pages/home')
-        }
-    };
+    var Controllers = plugin.controllers();
 
     plugin.route([
 

--- a/config/manifest.js
+++ b/config/manifest.js
@@ -113,6 +113,15 @@ internals.manifest = {
             }
         },
 
+        {
+            plugin: {
+                register: './lib/controllers',
+                options: {
+                    path: './app/controllers'
+                }
+            }
+        },
+
         //  Core routes
         {
             plugin: './app/routes/core.js'

--- a/lib/controllers.js
+++ b/lib/controllers.js
@@ -13,7 +13,7 @@ const Glob = require('glob');
  * create an object representation of a directory containing
  * javascript source files
  *
- * @param {String} fpath folder javascript files
+ * @param {String} fpath folder containing javascript files
  * @returns {Object} representing a directory
  */
 const pack = function(fpath) {

--- a/lib/controllers.js
+++ b/lib/controllers.js
@@ -1,0 +1,63 @@
+'use strict';
+
+/**
+ * this plugin wraps up the controller module(s) into
+ * a server method called `.controllers()` that can then be accessed later
+ * by route plugins.
+ */
+
+const Path = require('path');
+const Glob = require('glob');
+
+/**
+ * create an object representation of a directory containing
+ * javascript source files
+ *
+ * @param {String} fpath folder javascript files
+ * @returns {Object} representing a directory
+ */
+const pack = function(fpath) {
+    fpath = Path.resolve(fpath);
+    const pattern = Path.join(fpath, '**/**.js');
+    const files = Glob.sync(pattern);
+    const result = {};
+    files.forEach((file) => {
+        const module = require(file);
+
+        // remove the common abspath
+        file = file.replace(fpath, '');
+
+        // remove the file extension at the end
+        file = file.replace(/\.js$/, '');
+
+        // remove the trailing slash
+        file = file[0] === Path.sep?file.slice(1):file;
+
+        let components = file.split('/').reverse();
+        let head = result;
+        while ( components.length > 0 ) {
+            const el = components.pop();
+            if ( !components.length ) {
+                head[el] = module;
+            } else if ( head[el] === undefined ) {
+                head[el] = {};
+            }
+            head = head[el];
+        }
+    });
+    return result;
+};
+
+exports.register = function(server, options, next) {
+    const controllers = pack(options.path);
+    server.decorate('server', 'controllers', function() {
+        return controllers;
+    });
+    next();
+};
+
+exports.register.attributes = {
+    name: 'controller_package',
+    version: require('../package.json').version
+};
+


### PR DESCRIPTION
# Why?

So far, we've been creating a local controller object manually for each individual route plugin. It is a process that has to be repeated for every new route plugin that is added to the app.

This patch proposes the addition of a `controllers` plugin that decorates the `server` object with a `.controllers()` method. The method generates an object representation of the `app/controllers` folder, which simplifies the process of writing route plugins.

I believe that this approach is superior to the current one in two regards:
- It makes the code more DRY
- It eliminates the need for a `cousin import`. (where controllers were require()'d by going up a directory and then into another sub directory)

cousin imports are a code smell, since ideally all imports should be from siblings and decendents, not from cousin or parents.  
# Considerations

some area's of concern:
- In the current system, only controller's that were specifically `require()`'d were available. However in the new system, all controllers will be available. This goes against the principle of least privilege. Although that won't be the end of the world
- This will only add more to the complexity. Since `jolly` doesn't have an express philosophy, while this might not be breaking any conventions, it does add to the pile. 
