### PR TITLE
reduce verbosity around `try` mode

### DIFF
--- a/app/controllers/auth/email-verify.js
+++ b/app/controllers/auth/email-verify.js
@@ -11,11 +11,6 @@ exports.sendVerification = {
         mode: 'try',
         strategy: 'standard'
     },
-    plugins: {
-        'hapi-auth-cookie': {
-            redirectTo: false // To prevent redirect loop
-        }
-    },
     handler: function(request, reply) {
         
         // Generate Token
@@ -72,11 +67,6 @@ exports.verifyEmail = {
     auth: {
         mode: 'try',
         strategy: 'standard'
-    },
-    plugins: {
-        'hapi-auth-cookie': {
-            redirectTo: false // To stop from redirect loop
-        }
     },
     handler: function(request, reply) {
 

--- a/app/controllers/auth/login.js
+++ b/app/controllers/auth/login.js
@@ -10,11 +10,6 @@ exports.showForm = {
         mode: 'try',
         strategy: 'standard'
     },
-    plugins: {
-        'hapi-auth-cookie': {
-            redirectTo: false // To prevent redirect loop
-        }
-    },
     handler: function(request, reply) {
 
         if (request.auth.isAuthenticated) {
@@ -32,9 +27,6 @@ exports.postForm = {
         strategy: 'standard'
     },
     plugins: {
-        'hapi-auth-cookie': {
-            redirectTo: false
-        },
         crumb: {
             key: 'crumb',
             source: 'payload',

--- a/app/controllers/auth/password-forgot.js
+++ b/app/controllers/auth/password-forgot.js
@@ -11,9 +11,6 @@ exports.showRecoveryForm = {
         strategy: 'standard'
     },
     plugins: {
-        'hapi-auth-cookie': {
-            redirectTo: false // To stop from redirect loop
-        },
         crumb: {
             key: 'crumb',
             source: 'payload',
@@ -31,11 +28,6 @@ exports.postRecoveryForm = {
     auth: {
         mode: 'try',
         strategy: 'standard'
-    },
-    plugins: {
-        'hapi-auth-cookie': {
-            redirectTo: false // To stop from redirect loop
-        }
     },
     validate: {
         payload: {

--- a/app/controllers/auth/password-reset.js
+++ b/app/controllers/auth/password-reset.js
@@ -9,11 +9,6 @@ exports.showResetForm = {
         mode: 'try',
         strategy: 'standard'
     },
-    plugins: {
-        'hapi-auth-cookie': {
-            redirectTo: false // To stop from redirect loop
-        }
-    },
     handler: function(request, reply) {
 
         var ctx = {};
@@ -39,11 +34,6 @@ exports.postResetForm = {
     auth: {
         mode: 'try',
         strategy: 'standard'
-    },
-    plugins: {
-        'hapi-auth-cookie': {
-            redirectTo: false // To stop from redirect loop
-        }
     },
     validate: {
         payload: {

--- a/app/controllers/auth/signup.js
+++ b/app/controllers/auth/signup.js
@@ -11,11 +11,6 @@ exports.showForm = {
         mode: 'try',
         strategy: 'standard'
     },
-    plugins: {
-        'hapi-auth-cookie': {
-            redirectTo: false // To stop from redirect loop
-        }
-    },
     handler: function(request, reply) {
         if (request.auth.isAuthenticated) {
             return reply.redirect('/account');
@@ -29,11 +24,6 @@ exports.postForm = {
     auth: {
         mode: 'try',
         strategy: 'standard'
-    },
-    plugins: {
-        'hapi-auth-cookie': {
-            redirectTo: false // To stop from redirect loop
-        }
     },
     validate: {
         payload: {

--- a/app/controllers/pages/home.js
+++ b/app/controllers/pages/home.js
@@ -6,11 +6,6 @@ exports.view = {
         mode: 'try',
         strategy: 'standard'
     },
-    plugins: {
-        'hapi-auth-cookie': {
-            redirectTo: false // '/login' if set redirects to ./login.
-        }
-    },
     handler: function(request, reply) {
 
         reply.view('homepage');

--- a/lib/auth.js
+++ b/lib/auth.js
@@ -8,7 +8,8 @@ exports.register = function(server, options, next) {
             isSecure: false, // required for non-https applications
             clearInvalid: true,
             ttl: 24 * 60 * 60 * 1000, // Set session to 1 day
-            redirectTo: '/login'
+            redirectTo: '/login',
+            redirectOnTry: false,
         });
 
         // Blacklist all routes.


### PR DESCRIPTION
# The Problem

every time we create a route that uses the `try` mode, we'd also need to tell `hapi-auth-cookie` that we don't want it to redirect the user to the login page. This had to been done for every route that used the `try` mode  
# The Solution

`hapi-auth-cookie` features a configuration flag called `redirectOnTry` which basically disables redirection on all routes that employ the `try` mode. If any route wants redirection with `try` mode, it can ask for it by using `route.config.plugins`. To demonstrate:

``` js

server.route({
    path: '/',
    method: 'GET',
    plugins: {
        'hapi-auth-cookie': {
            redirectOnTry: true
        }
    },
    auth: 'standard',
    handler: function(request, reply) {
        reply().code(200);
    }
});
```
